### PR TITLE
fix: 尝试修复抽屉的 URL 更新

### DIFF
--- a/src/inject/index.js
+++ b/src/inject/index.js
@@ -33,11 +33,12 @@ function injectFunction(
   }
 }
 
+// 扩展监听的方法，增加 replaceState
 injectFunction(
   window.history,
-  ['pushState', 'forward', 'replaceState'],
+  ['pushState'],
   (...args) => {
-    window.dispatchEvent(new CustomEvent('historyChange', { detail: args }))
+    window.dispatchEvent(new CustomEvent('pushstate', { detail: args }))
   },
 )
 

--- a/src/inject/index.js
+++ b/src/inject/index.js
@@ -33,7 +33,7 @@ function injectFunction(
   }
 }
 
-// 扩展监听的方法，增加 replaceState
+// 注入 history.pushState 调用以触发自定义的 pushstate 事件，用于监控 iframe drawer 路由变化
 injectFunction(
   window.history,
   ['pushState'],


### PR DESCRIPTION
<!-- see: https://github.com/VentusUta/BewlyBewly-AveMujica/blob/main/docs/CONTRIBUTING.md -->
<!-- We may not respond to your issue or PR. -->
<!-- We may close an issue or PR without much feedback. -->
closes #22。
1. 参考 @keleus 的代码，将对 iframe 的事件监听逻辑移动到 iframeRef.value load 之后；
2. 之前监听到 pushState 调用后直接取 iframe url 是未经更新的值，由于 pushState 的参数保存在了自定义事件的 detail 字段中，修改成直接从 detail 字段中取；
3. 修改 updateCurrentUrl 的逻辑，移除 currentUrl 的修改、将 pushState 修改为 replaceState，测试下来不影响逻辑，还能减少 history length；

测试修改后 chromium 系和 firefox 系表现基本一致，唯一区别是 firefox 系浏览器在抽屉返回到初始页时需要额外点击一次返回才能关闭抽屉。

个人推测是两者对 iframe 返回的处理不同，chromium 的 iframe 无法继续返回时下次返回直接由 parent 响应，firefox 的 iframe 无法继续返回时按一次返回只会将焦点返回 parent，再点一次返回才会由 parent 响应？