### PR TITLE
fix: 修复视频卡片已关注标记的描边样式

### DIFF
--- a/src/components/VideoCard/VideoCardAuthor/components/VideoCardAuthorAvatar.vue
+++ b/src/components/VideoCard/VideoCardAuthor/components/VideoCardAuthorAvatar.vue
@@ -61,7 +61,7 @@ const displayedAvatars = computed(() => {
         pos="absolute top-21px left-22px"
         w-14px h-14px
         bg="$bew-theme-color"
-        border="2 outset solid white"
+        border="2 solid white"
         rounded="1/2"
         grid place-items-center
       >


### PR DESCRIPTION
<!-- see: https://github.com/VentusUta/BewlyBewly-AveMujica/blob/main/docs/CONTRIBUTING.md -->
<!-- We may not respond to your issue or PR. -->
<!-- We may close an issue or PR without much feedback. -->
Before:
<img width="125" alt="image" src="https://github.com/user-attachments/assets/d6632c11-b7ed-4545-bc63-751c5936ab52" />

After:
<img width="138" alt="image" src="https://github.com/user-attachments/assets/03f4f86a-3c41-4d30-be12-a3c91fd95bc4" />
