### PR TITLE
fix(IframeDrawer): prevent content shift in web fullscreen mode

### DIFF
--- a/src/components/IframeDrawer.vue
+++ b/src/components/IframeDrawer.vue
@@ -35,16 +35,14 @@ function setupIframeListeners() {
     useEventListener(iframeRef.value?.contentWindow, 'pushstate', updateCurrentUrl)
     useEventListener(iframeRef.value?.contentWindow, 'popstate', updateCurrentUrl)
 
-    useEventListener(iframeRef.value?.contentWindow, 'DOMContentLoaded', () => {
-      if (headerShow.value) {
-        iframeRef.value?.contentWindow?.document.documentElement.classList.add('remove-top-bar-without-placeholder')
-        removeTopBarClassInjected.value = true
-      }
-      else {
-        iframeRef.value?.contentWindow?.document.documentElement.classList.remove('remove-top-bar-without-placeholder')
-        removeTopBarClassInjected.value = false
-      }
-    })
+    if (headerShow.value) {
+      iframeRef.value?.contentWindow?.document.documentElement.classList.add('remove-top-bar-without-placeholder')
+      removeTopBarClassInjected.value = true
+    }
+    else {
+      iframeRef.value?.contentWindow?.document.documentElement.classList.remove('remove-top-bar-without-placeholder')
+      removeTopBarClassInjected.value = false
+    }
   })
 }
 


### PR DESCRIPTION
### 问题描述

启用抽屉模式，在抽屉中打开视频网页全屏时，视频会向上偏移错位，参考 issue #36

### 原因分析

  ```typescript
  // 原本的嵌套结构（由 #24 引入）
  useEventListener(iframe, 'load', () => {
    ...
    useEventListener(contentWindow, 'DOMContentLoaded', ...)
  })
```

- 事件 `DOMContentLoaded` 监听器嵌套在 `load` 监听器内
- 由于 `DOMContentLoaded` 通常在 `load` 之前触发，事件 `DOMContentLoaded` 错过触发时机（根本不被触发）
- 导致 `remove-top-bar-without-placeholder` 类未能增/删
- 造成 iframe 应用 `calc(-1 * var(--bew-top-bar-height))`
- 在网页全屏模式下导致内容上移

> Chromium 系和 Firefox 系浏览器均有此问题

### 此 PR 做的修改

- 移除 `DOMContentLoaded` 监听器，改为在 `load` 事件后直接触发类名修改
  （由于 `load` 总是晚于 `DOMContentLoaded` 触发，因此总是可以正确运行

### 修复效果

实测在 Chromium 系和 Firefox 系浏览器上都能稳定不错位，且抽屉 URL 伴随视频内容跳转变化

（即不会导致 issue #22 的复现）

Fix #36

<!-- see: https://github.com/VentusUta/BewlyBewly-AveMujica/blob/main/docs/CONTRIBUTING.md -->
<!-- We may not respond to your issue or PR. -->
<!-- We may close an issue or PR without much feedback. -->
