### PR TITLE
fix(IframeDrawer): 解决 iframe 无法自动聚焦的问题

### DIFF
--- a/src/components/IframeDrawer.vue
+++ b/src/components/IframeDrawer.vue
@@ -43,6 +43,8 @@ function setupIframeListeners() {
       iframeRef.value?.contentWindow?.document.documentElement.classList.remove('remove-top-bar-without-placeholder')
       removeTopBarClassInjected.value = false
     }
+
+    iframeRef.value?.focus()
   })
 }
 
@@ -53,7 +55,6 @@ onMounted(() => {
   nextTick(() => {
     if (iframeRef.value) {
       setupIframeListeners()
-      iframeRef.value?.focus()
     }
   })
 })


### PR DESCRIPTION
### 原因分析

  ```typescript
onMounted(() => {
  ...
  nextTick(() => {
    if (iframeRef.value) {
      setupIframeListeners()
      iframeRef.value?.focus() // 此处
    }
  })
})

```

原有的调用是在挂载时，未确认 DOM 就绪，造成可能无法取得焦点（经过测试发现焦点仍在主页）

### 此 PR 做的修改

将聚焦调用移至 iframe `load`事件后，确保 DOM 完全加载后再获取焦点。


```typescript
function setupIframeListeners() {
  ...
  useEventListener(iframeRef.value, 'load', () => {
    ...
    iframeRef.value?.focus()
  })
}

```

### 修复效果

实测在以下浏览器上都能稳定取得焦点，可直接通过键盘按键控制抽屉内的网页。
|浏览器|版本|
|---|---|
| Microsoft Edge|138.0.3351.121 (正式版本) (64 位)|
| Firefox Developer Edition|142.0b5 (64 位)|

Fix #48 

<!-- see: https://github.com/VentusUta/BewlyBewly-AveMujica/blob/main/docs/CONTRIBUTING.md -->
<!-- We may not respond to your issue or PR. -->
<!-- We may close an issue or PR without much feedback. -->
