### PR TITLE
fix(i18n): normalize language labels and default wording in settings

### DIFF
--- a/src/_locales/cmn-CN.yml
+++ b/src/_locales/cmn-CN.yml
@@ -109,12 +109,12 @@ settings:
   select_language: 界面语言
   select_language_opt:
     english: 英文
-    mandarin_cn: 官话 - 简体中文
-    mandarin_tw: 官話 - 繁体中文
-    jyut: 廣東話
+    mandarin_cn: 简体中文
+    mandarin_tw: 繁体中文
+    jyut: 粤语
   customize_font: 自定义字体
   font_opt:
-    default: 缺省
+    default: 默认
     recommend: 推荐A（使用旧字形，更美观）
     recommend-new: 推荐B（使用常见字形，更习惯）
     custom: 自定义
@@ -123,7 +123,7 @@ settings:
     这些字形还具有将简体中文转换为繁体中文的能力。
   danmaku_font: 弹幕字体
   danmaku_font_opt:
-    default: 缺省
+    default: 默认
     override: 覆盖
     custom: 自定义
   remove_the_indent_from_chinese_punctuation: 移除中文标点符号的缩进

--- a/src/_locales/cmn-TW.yml
+++ b/src/_locales/cmn-TW.yml
@@ -109,12 +109,12 @@ settings:
   select_language: 介面語言
   select_language_opt:
     english: 英文
-    mandarin_cn: 官话 - 简体中文
-    mandarin_tw: 官話 - 繁體中文
-    jyut: 廣東話
+    mandarin_cn: 簡體中文
+    mandarin_tw: 繁體中文
+    jyut: 粵語
   customize_font: 自訂字型
   font_opt:
-    default: 缺省
+    default: 預設
     recommend: 推薦A（使用傳承字形，更美觀）
     recommend-new: 推薦B（使用常用字形，更習慣）
     custom: 自訂
@@ -123,7 +123,7 @@ settings:
     這些字型還具有將簡體中文轉換爲繁體中文的能力。
   danmaku_font: 彈幕字型
   danmaku_font_opt:
-    default: 缺省
+    default: 預設
     override: 覆蓋
     custom: 自訂
   remove_the_indent_from_chinese_punctuation: 移除中文標點符號的縮排

--- a/src/_locales/en.yml
+++ b/src/_locales/en.yml
@@ -111,8 +111,8 @@ settings:
   select_language: Language
   select_language_opt:
     english: English
-    mandarin_cn: Mandarin - Simplified Chinese
-    mandarin_tw: Mandarin - Traditional Chinese
+    mandarin_cn: Chinese (Simplified)
+    mandarin_tw: Chinese (Traditional)
     jyut: Cantonese
   customize_font: Customize font
   font_opt:

--- a/src/_locales/jyut.yml
+++ b/src/_locales/jyut.yml
@@ -109,12 +109,12 @@ settings:
   select_language: 介面語言
   select_language_opt:
     english: 英文
-    mandarin_cn: 官话 - 简体中文
-    mandarin_tw: 官話 - 繁體中文
-    jyut: 廣東話
+    mandarin_cn: 簡體中文
+    mandarin_tw: 繁體中文
+    jyut: 粵語
   customize_font: 自訂字型
   font_opt:
-    default: 缺省
+    default: 預設
     recommend: 推薦A（用傳統字形，靚啲）
     recommend-new: 推薦B（用常見字形，習慣啲）
     custom: 自訂
@@ -123,7 +123,7 @@ settings:
     呢啲字型仲可以將簡體中文轉做繁體中文。
   danmaku_font: 彈幕字型
   danmaku_font_opt:
-    default: 缺省
+    default: 預設
     override: 覆蓋
     custom: 自訂
   remove_the_indent_from_chinese_punctuation: 移除中文標點符號嘅縮排


### PR DESCRIPTION
## Background (Legacy Issue)
The current settings labels contain legacy wording such as:
- 官话 - 简体中文 / 官話 - 繁體中文
- 缺省
- Mixed script in UI labels (for example, Simplified Chinese UI showing 廣東話).

These terms were carried over from earlier versions and are less aligned with mainstream product i18n wording.

## Why This Change Is Justified
1. User-facing i18n should prioritize common, recognizable labels.
2. Script consistency within each locale UI.
3. 默认 / 預設 is more standard UX wording than 缺省.
4. No behavioral risk: this PR only changes display strings.

## What Changed
- src/_locales/cmn-CN.yml
  - 官话 - 简体中文 -> 简体中文
  - 官話 - 繁体中文 -> 繁体中文
  - 廣東話 -> 粤语
  - 缺省 -> 默认 (font + danmaku font)

- src/_locales/cmn-TW.yml
  - 官话 - 简体中文 -> 簡體中文
  - 官話 - 繁體中文 -> 繁體中文
  - 廣東話 -> 粵語
  - 缺省 -> 預設 (font + danmaku font)

- src/_locales/jyut.yml
  - 官话 - 简体中文 -> 簡體中文
  - 官話 - 繁體中文 -> 繁體中文
  - 廣東話 -> 粵語
  - 缺省 -> 預設 (font + danmaku font)

- src/_locales/en.yml
  - Mandarin - Simplified Chinese -> Chinese (Simplified)
  - Mandarin - Traditional Chinese -> Chinese (Traditional)

## Compatibility / Risk
- Compatibility: fully backward compatible (keys unchanged).
- Risk: very low (string-only changes).
