### PR TITLE
fix(top-bar): hide top bar in web fullscreen on bangumi pages

### DIFF
--- a/src/components/TopBar/OldTopBar.vue
+++ b/src/components/TopBar/OldTopBar.vue
@@ -8,7 +8,7 @@ import { OVERLAY_SCROLL_BAR_SCROLL, TOP_BAR_VISIBILITY_CHANGE } from '~/constant
 import { AppPage } from '~/enums/appEnums'
 import { settings } from '~/logic'
 import api from '~/utils/api'
-import { getUserID, isHomePage, removeHttpFromUrl } from '~/utils/main'
+import { getUserID, isHomePage, isInIframe, isVideoOrBangumiPage, queryDomUntilFound, removeHttpFromUrl } from '~/utils/main'
 import emitter from '~/utils/mitt'
 
 import ChannelsPop from './components/ChannelsPop.vue'
@@ -313,6 +313,35 @@ onUnmounted(() => {
   window.removeEventListener('scroll', handleScroll)
   emitter.off(OVERLAY_SCROLL_BAR_SCROLL)
 })
+
+// #region Hide the top bar when entering web fullscreen (网页全屏)
+// On normal video pages Bilibili's web-fullscreen player layer happens to cover the top bar,
+// but on bangumi pages (`/bangumi/play/`) it doesn't, leaving the top bar floating over the video.
+// So we explicitly detect web fullscreen via the player's web-fullscreen button state and hide the
+// top bar ourselves. (The drawer/iframe case is handled separately in App.vue.)
+let webFullscreenObserver: MutationObserver | null = null
+const webFullscreenAbort = new AbortController()
+
+onMounted(() => {
+  if (isInIframe() || !isVideoOrBangumiPage())
+    return
+
+  queryDomUntilFound('.bpx-player-ctrl-btn.bpx-player-ctrl-web', 500, webFullscreenAbort).then((webFullscreenBtn) => {
+    if (!webFullscreenBtn)
+      return
+
+    webFullscreenObserver = new MutationObserver(() => {
+      toggleTopBarVisible(!webFullscreenBtn.classList.contains('bpx-state-entered'))
+    })
+    webFullscreenObserver.observe(webFullscreenBtn, { attributes: true, attributeFilter: ['class'] })
+  })
+})
+
+onUnmounted(() => {
+  webFullscreenObserver?.disconnect()
+  webFullscreenAbort.abort()
+})
+// #endregion
 
 async function initData() {
   await getUserInfo()

--- a/src/components/TopBar/TopBar.vue
+++ b/src/components/TopBar/TopBar.vue
@@ -9,7 +9,7 @@ import { OVERLAY_SCROLL_BAR_SCROLL, TOP_BAR_VISIBILITY_CHANGE } from '~/constant
 import { AppPage } from '~/enums/appEnums'
 import { settings } from '~/logic'
 import api from '~/utils/api'
-import { getUserID, isHomePage, isInIframe, removeHttpFromUrl } from '~/utils/main'
+import { getUserID, isHomePage, isInIframe, isVideoOrBangumiPage, queryDomUntilFound, removeHttpFromUrl } from '~/utils/main'
 import emitter from '~/utils/mitt'
 import { createTransformer } from '~/utils/transformer'
 
@@ -342,6 +342,35 @@ onUnmounted(() => {
   window.removeEventListener('scroll', handleScroll)
   emitter.off(OVERLAY_SCROLL_BAR_SCROLL)
 })
+
+// #region Hide the top bar when entering web fullscreen (网页全屏)
+// On normal video pages Bilibili's web-fullscreen player layer happens to cover the top bar,
+// but on bangumi pages (`/bangumi/play/`) it doesn't, leaving the top bar floating over the video.
+// So we explicitly detect web fullscreen via the player's web-fullscreen button state and hide the
+// top bar ourselves. (The drawer/iframe case is handled separately in App.vue.)
+let webFullscreenObserver: MutationObserver | null = null
+const webFullscreenAbort = new AbortController()
+
+onMounted(() => {
+  if (isInIframe() || !isVideoOrBangumiPage())
+    return
+
+  queryDomUntilFound('.bpx-player-ctrl-btn.bpx-player-ctrl-web', 500, webFullscreenAbort).then((webFullscreenBtn) => {
+    if (!webFullscreenBtn)
+      return
+
+    webFullscreenObserver = new MutationObserver(() => {
+      toggleTopBarVisible(!webFullscreenBtn.classList.contains('bpx-state-entered'))
+    })
+    webFullscreenObserver.observe(webFullscreenBtn, { attributes: true, attributeFilter: ['class'] })
+  })
+})
+
+onUnmounted(() => {
+  webFullscreenObserver?.disconnect()
+  webFullscreenAbort.abort()
+})
+// #endregion
 
 async function initData() {
   await getUserInfo()


### PR DESCRIPTION
## Summary

On bangumi playback pages (e.g. <https://www.bilibili.com/bangumi/play/ep468252>), enabling **网页全屏 (web fullscreen)** does not hide BewlyBewly's top bar — it stays floating over the video. On normal video pages it hides as expected.

## Cause

There is no explicit "hide top bar on web fullscreen" logic for normal (non-drawer) pages. On regular video pages the top bar merely happens to be painted over by Bilibili's web-fullscreen player layer (the top bar sits below at `z-index: 99`). On bangumi pages (`/bangumi/play/`, a different player/React structure) that incidental covering does not happen, so the top bar stays visible.

The only existing web-fullscreen detection in `App.vue` is gated behind `isInIframe()` and exclusively serves the *open in drawer* feature, so it never runs for normal pages.

## Fix

Detect web fullscreen explicitly inside the top bar components by observing the player's web-fullscreen control button (`.bpx-player-ctrl-btn.bpx-player-ctrl-web` toggling the `bpx-state-entered` class) and hiding/showing the top bar accordingly.

- Applied to both `TopBar.vue` and the deprecated `OldTopBar.vue`.
- Only activates on video/bangumi pages and not inside the drawer iframe; the observer is disconnected and the DOM-poll aborted on unmount.
- The drawer/iframe path in `App.vue` is left untouched.

## Testing

- `bun run build`, loaded unpacked in Chrome.
- Bangumi page → toggle 网页全屏 → top bar now hides and restores correctly. ✅
- Regular video page → behavior unchanged. ✅

## Note

This change was implemented with the assistance of **Claude Opus 4.8**.

🤖 Generated with [Claude Code](https://claude.com/claude-code)